### PR TITLE
unserialize should raise exception on not serialized input

### DIFF
--- a/src/Adapter/PhpSerialize.php
+++ b/src/Adapter/PhpSerialize.php
@@ -64,8 +64,8 @@ class PhpSerialize extends AbstractAdapter
      */
     public function unserialize($serialized)
     {
-        if (!is_string($serialized) || !preg_match('/^((s|i|d|b|a|O|C):|N;)/', $serialized)) {
-            return $serialized;
+        if (!is_string($serialized)) {
+            throw new Exception\RuntimeException('Serialized data must be a string');
         }
 
         // If we have a serialized boolean false value, just return false;

--- a/test/Adapter/PhpSerializeTest.php
+++ b/test/Adapter/PhpSerializeTest.php
@@ -122,15 +122,19 @@ class PhpSerializeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $data);
     }
 
-    public function testUnserializingNonserializedStringReturnsItVerbatim()
+    public function testUnserializingNoStringRaisesException()
     {
-        $value = 'not a serialized string';
-        $this->assertEquals($value, $this->adapter->unserialize($value));
+        $value = null;
+        $this->setExpectedException(
+            'Zend\Serializer\Exception\RuntimeException',
+            'Serialized data must be a string'
+        );
+        $this->adapter->unserialize($value);
     }
 
     public function testUnserializingInvalidStringRaisesException()
     {
-        $value = 'a:foobar';
+        $value = 'foobar';
         $this->setExpectedException('Zend\Serializer\Exception\RuntimeException');
         $this->adapter->unserialize($value);
     }


### PR DESCRIPTION
Every adapter should raise an exception if the input for `unserialize` is not a serialized string.

The bug was introduced on Dec 16, 2011 here https://github.com/zendframework/zf2/commit/64f4d52f40873996a6b21aeee82cdedb047ceb53#diff-4ae37c6308a6960757fa49d2da5f1485R106
