### PR TITLE
More aliases, fewer factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "zendframework/zend-stdlib": "~2.7",
         "zendframework/zend-json": "~2.5",
         "zendframework/zend-math": "dev-develop as 2.6.0"

--- a/src/AdapterPluginManager.php
+++ b/src/AdapterPluginManager.php
@@ -41,7 +41,7 @@ class AdapterPluginManager extends AbstractPluginManager
         'pythonPickle' => Adapter\PythonPickle::class,
         'PythonPickle' => Adapter\PythonPickle::class,
         'wddx'         => Adapter\Wddx::class,
-        'Wddx'         => Adapter\Wddx::class
+        'Wddx'         => Adapter\Wddx::class,
     ];
 
     protected $factories = [
@@ -52,6 +52,16 @@ class AdapterPluginManager extends AbstractPluginManager
         Adapter\PhpSerialize::class => InvokableFactory::class,
         Adapter\PythonPickle::class => InvokableFactory::class,
         Adapter\Wddx::class         => InvokableFactory::class,
+        // Legacy (v2) due to alias resolution; canonical form of resolved
+        // alias is used to look up the factory, while the non-normalized
+        // resolved alias is used as the requested name passed to the factory.
+        'zendserializeradapterigbinary' => InvokableFactory::class,
+        'zendserializeradapterjson' => InvokableFactory::class,
+        'zendserializeradaptermsgpack' => InvokableFactory::class,
+        'zendserializeradapterphpcode' => InvokableFactory::class,
+        'zendserializeradapterphpserialize' => InvokableFactory::class,
+        'zendserializeradapterpythonpickle' => InvokableFactory::class,
+        'zendserializeradapterwddx' => InvokableFactory::class,
     ];
 
     protected $instanceOf = Adapter\AdapterInterface::class;

--- a/src/AdapterPluginManager.php
+++ b/src/AdapterPluginManager.php
@@ -24,36 +24,34 @@ class AdapterPluginManager extends AbstractPluginManager
 {
     protected $aliases = [
         'igbinary'     => Adapter\IgBinary::class,
+        'igBinary'     => Adapter\IgBinary::class,
         'IgBinary'     => Adapter\IgBinary::class,
         'json'         => Adapter\Json::class,
         'Json'         => Adapter\Json::class,
         'msgpack'      => Adapter\MsgPack::class,
+        'msgPack'      => Adapter\MsgPack::class,
         'MsgPack'      => Adapter\MsgPack::class,
         'phpcode'      => Adapter\PhpCode::class,
+        'phpCode'      => Adapter\PhpCode::class,
         'PhpCode'      => Adapter\PhpCode::class,
         'phpserialize' => Adapter\PhpSerialize::class,
+        'phpSerialize' => Adapter\PhpSerialize::class,
         'PhpSerialize' => Adapter\PhpSerialize::class,
         'pythonpickle' => Adapter\PythonPickle::class,
+        'pythonPickle' => Adapter\PythonPickle::class,
         'PythonPickle' => Adapter\PythonPickle::class,
         'wddx'         => Adapter\Wddx::class,
         'Wddx'         => Adapter\Wddx::class
     ];
 
     protected $factories = [
-        Adapter\IgBinary::class             => InvokableFactory::class,
-        'zendserializeradapterigbinary'     => InvokableFactory::class,
-        Adapter\Json::class                 => InvokableFactory::class,
-        'zendserializeradapterjson'         => InvokableFactory::class,
-        Adapter\MsgPack::class              => InvokableFactory::class,
-        'zendserializeradaptermsgpack'      => InvokableFactory::class,
-        Adapter\PhpCode::class              => InvokableFactory::class,
-        'zendserializeradapter\phpcode'     => InvokableFactory::class,
-        Adapter\PhpSerialize::class         => InvokableFactory::class,
-        'zendserializeradapterphpserialize' => InvokableFactory::class,
-        Adapter\PythonPickle::class         => InvokableFactory::class,
-        'zendserializeradapterpythonpickle' => InvokableFactory::class,
-        Adapter\Wddx::class                 => InvokableFactory::class,
-        'zendserializeradapterwddx'         => InvokableFactory::class
+        Adapter\IgBinary::class     => InvokableFactory::class,
+        Adapter\Json::class         => InvokableFactory::class,
+        Adapter\MsgPack::class      => InvokableFactory::class,
+        Adapter\PhpCode::class      => InvokableFactory::class,
+        Adapter\PhpSerialize::class => InvokableFactory::class,
+        Adapter\PythonPickle::class => InvokableFactory::class,
+        Adapter\Wddx::class         => InvokableFactory::class,
     ];
 
     protected $instanceOf = Adapter\AdapterInterface::class;


### PR DESCRIPTION
- Aliases typically need to be in each of:
  - lowercase
  - camelCase
  - TitleCase
- Factories mapping to the `InvokableFactory` _must_ be FQCNs _only_. The normalized version used in v2 (stripping special characters and lowercasing) will likely never be used to retrieve a service, and can be skipped.
