### PR TITLE
Additional servicemanager forwards compat testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,23 +19,22 @@ matrix:
         - EXECUTE_CS_CHECK=true
     - php: 5.5
       env:
-        - SERVICE_MANAGER_VERSION='>=2.7.3,<3.0'
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
     - php: 5.6
       env:
-        - SERVICE_MANAGER_VERSION='>=2.7.3,<3.0'
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 7
     - php: 7
       env:
-        - SERVICE_MANAGER_VERSION='>=2.7.3,<3.0'
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: hhvm
     - php: hhvm
       env:
-        - SERVICE_MANAGER_VERSION='>=2.7.3,<3.0'
+        - SERVICE_MANAGER_VERSION='^2.7.5'
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         "php": "^5.5 || ^7.0",
         "zendframework/zend-stdlib": "~2.7",
         "zendframework/zend-json": "~2.5",
-        "zendframework/zend-math": "dev-develop as 2.6.0"
+        "zendframework/zend-math": "^2.6"
     },
     "require-dev": {
-        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/AdapterPluginManager.php
+++ b/src/AdapterPluginManager.php
@@ -92,10 +92,14 @@ class AdapterPluginManager extends AbstractPluginManager
      * Proxies to `validate()`.
      *
      * @param mixed $instance
-     * @throws InvalidServiceException
+     * @throws Exception\RuntimeException
      */
     public function validatePlugin($instance)
     {
-        $this->validate($instance);
+        try {
+            $this->validate($instance);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 }

--- a/test/AdapterPluginManagerCompatibilityTest.php
+++ b/test/AdapterPluginManagerCompatibilityTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-serializer for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Serializer;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+use Zend\Serializer\AdapterPluginManager;
+use Zend\Serializer\Adapter;
+use Zend\Serializer\Exception\RuntimeException;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class AdapterPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new AdapterPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return RuntimeException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return Adapter\AdapterInterface::class;
+    }
+
+    /**
+     * Overrides CommonPluginManagerTrait::aliasProvider
+     *
+     * Iterates through aliases, and for adapters that require extensions,
+     * tests if the extension is loaded, skipping that alias if not.
+     *
+     * @return \Traversable
+     */
+    public function aliasProvider()
+    {
+        $pluginManager = $this->getPluginManager();
+        $r = new ReflectionProperty($pluginManager, 'aliases');
+        $r->setAccessible(true);
+        $aliases = $r->getValue($pluginManager);
+
+        foreach ($aliases as $alias => $target) {
+            switch ($target) {
+                case Adapter\IgBinary::class:
+                    if (extension_loaded('igbinary')) {
+                        yield $alias => [$alias, $target];
+                    }
+                    break;
+                case Adapter\MsgPack::class:
+                    if (extension_loaded('msgpack')) {
+                        yield $alias => [$alias, $target];
+                    }
+                    break;
+                case Adapter\Wddx::class:
+                    if (extension_loaded('wddx')) {
+                        yield $alias => [$alias, $target];
+                    }
+                    break;
+                default:
+                    yield $alias => [$alias, $target];
+            }
+        }
+    }
+}

--- a/test/SerializerTest.php
+++ b/test/SerializerTest.php
@@ -11,7 +11,9 @@ namespace ZendTest\Serializer;
 
 use Zend\Serializer\Adapter;
 use Zend\Serializer\AdapterPluginManager;
+use Zend\Serializer\Exception\RuntimeException;
 use Zend\Serializer\Serializer;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\ServiceManager;
 
 /**
@@ -69,8 +71,17 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
         Serializer::setAdapterPluginManager($adapters);
-        $this->setExpectedException('Zend\ServiceManager\Exception\InvalidServiceException', 'AdapterInterface');
-        Serializer::factory('dummy');
+
+        try {
+            Serializer::factory('dummy');
+            $this->fail('Expected exception when requesting invalid adapter type');
+        } catch (InvalidServiceException $e) {
+            $this->assertContains('Dummy is invalid', $e->getMessage());
+        } catch (RuntimeException $e) {
+            $this->assertContains('Dummy is invalid', $e->getMessage());
+        } catch (\Exception $e) {
+            $this->fail('Unexpected exception raised by plugin manager for invalid adapter type');
+        }
     }
 
     public function testChangeDefaultAdapterWithString()


### PR DESCRIPTION
This patch follows the latest guidelines from under [the wiki](https://github.com/zendframework/maintainers/wiki/ZF3-ServiceManager-component-refactors,-phase-2) with regards to plugin manager behavior and testing, introducing a new test case, `AdapterPluginManagerCompatibilityTest`. Tests have been executed under both v2 and v3.
