### PR TITLE
Updated dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "zendframework/zend-stdlib": "~2.7",
-        "zendframework/zend-json": "~2.5",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0",
+        "zendframework/zend-json": "^2.5",
         "zendframework/zend-math": "^2.6"
     },
     "require-dev": {
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
+        "phpunit/PHPUnit": "^4.0"
     },
     "suggest": {
         "zendframework/zend-servicemanager": "To support plugin manager support"


### PR DESCRIPTION
- Use `^` operator when possible
- Updated zend-stdlib to `^2.7 || ^3.0`, as the changes in zend-stdlib 3.0 will not affect the functionality in this repository. This allows it to be used as a dev dependency for zend-stdlib v3 as well.
