### PR TITLE
Make zend-math optional as needed only with Python Pickle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "zendframework/zend-json": "^2.5"
     },
     "require-dev": {
+        "zendframework/zend-math": "^2.6",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/phpunit": "^4.5"

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
-        "zendframework/zend-json": "^2.5",
-        "zendframework/zend-math": "^2.6"
+        "zendframework/zend-json": "^2.5"
     },
     "require-dev": {
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
@@ -24,6 +23,7 @@
         "phpunit/phpunit": "^4.5"
     },
     "suggest": {
+        "zendframework/zend-math": "(^2.6) To support Python Pickle serialization",
         "zendframework/zend-servicemanager": "To support plugin manager support"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
In this component zend-math is required only for Python Pickle serialization, for sure not a common thing.

We can lighten this package without mandatorily requiring it.
